### PR TITLE
Add support for variable paging

### DIFF
--- a/src/phpDebug.ts
+++ b/src/phpDebug.ts
@@ -241,8 +241,6 @@ class PhpDebugSession extends vscode.DebugSession {
                     const initPacket = await connection.waitForInitPacket();
                     this.sendEvent(new vscode.ThreadEvent('started', connection.id));
                     await connection.sendFeatureSetCommand('max_depth', '5');
-                    // raise default of 32
-                    await connection.sendFeatureSetCommand('max_children', '100');
                     // don't truncate long variable values
                     await connection.sendFeatureSetCommand('max_data', semver.lt(initPacket.engineVersion.replace(/((?:dev|alpha|beta|RC|stable)\d*)$/, '-$1'), '2.2.4') ? '10000' : '0');
                     // request breakpoints from VS Code
@@ -661,7 +659,7 @@ class PhpDebugSession extends vscode.DebugSession {
                         if (property.children.length === property.numberOfChildren) {
                             properties = property.children;
                         } else {
-                            properties = await property.getChildren();
+                            properties = await property.getChildren(args.start);
                         }
                     } else {
                         properties = [];
@@ -695,6 +693,9 @@ class PhpDebugSession extends vscode.DebugSession {
                         type: property.type,
                         variablesReference
                     };
+                    if (property.hasChildren) {
+                        variable.namedVariables = property.numberOfChildren;
+                    }
                     return variable;
                 });
             }

--- a/src/test/adapter.ts
+++ b/src/test/adapter.ts
@@ -451,11 +451,11 @@ describe('PHP Debug Adapter', () => {
                 assert.propertyVal(aLargeArray!, 'value', 'array(100)');
                 assert.property(aLargeArray!, 'variablesReference');
                 const largeArrayItems = (await client.variablesRequest({variablesReference: aLargeArray!.variablesReference})).body.variables;
-                assert.lengthOf(largeArrayItems, 100);
+                assert.lengthOf(largeArrayItems, 32);
                 assert.propertyVal(largeArrayItems[0], 'name', '0');
                 assert.propertyVal(largeArrayItems[0], 'value', '"test"');
-                assert.propertyVal(largeArrayItems[99], 'name', '99');
-                assert.propertyVal(largeArrayItems[99], 'value', '"test"');
+                assert.propertyVal(largeArrayItems[31], 'name', '99');
+                assert.propertyVal(largeArrayItems[31], 'value', '"test"');
             });
 
             it('should report keys with spaces correctly', async () => {

--- a/src/test/adapter.ts
+++ b/src/test/adapter.ts
@@ -454,7 +454,7 @@ describe('PHP Debug Adapter', () => {
                 assert.lengthOf(largeArrayItems, 32);
                 assert.propertyVal(largeArrayItems[0], 'name', '0');
                 assert.propertyVal(largeArrayItems[0], 'value', '"test"');
-                assert.propertyVal(largeArrayItems[31], 'name', '99');
+                assert.propertyVal(largeArrayItems[31], 'name', '31');
                 assert.propertyVal(largeArrayItems[31], 'value', '"test"');
             });
 


### PR DESCRIPTION
`namedVariables` is correctly returned as being larger than the actual number of returned variables, but VS Code refuses to do any follow-up requests for paging or show any UI. I guess it is not implemented yet?
