### PR TITLE
Refactor continue events to avoid UI hanging

### DIFF
--- a/src/phpDebug.ts
+++ b/src/phpDebug.ts
@@ -945,7 +945,6 @@ class PhpDebugSession extends vscode.DebugSession {
         response: VSCodeDebugProtocol.DisconnectResponse,
         args: VSCodeDebugProtocol.DisconnectArguments
     ) {
-        this.sendResponse(response)
         try {
             await Promise.all(
                 Array.from(this._connections).map(async ([id, connection]) => {
@@ -969,6 +968,7 @@ class PhpDebugSession extends vscode.DebugSession {
             this.sendErrorResponse(response, error)
             return
         }
+        this.sendResponse(response)
         this.shutdown()
     }
 

--- a/src/phpDebug.ts
+++ b/src/phpDebug.ts
@@ -889,88 +889,52 @@ class PhpDebugSession extends vscode.DebugSession {
         response: VSCodeDebugProtocol.ContinueResponse,
         args: VSCodeDebugProtocol.ContinueArguments
     ) {
-        let xdebugResponse: xdebug.StatusResponse | undefined
-        try {
-            const connection = this._connections.get(args.threadId)
-            if (!connection) {
-                throw new Error('Unknown thread ID ' + args.threadId)
-            }
-            xdebugResponse = await connection.sendRunCommand()
-        } catch (error) {
-            this.sendErrorResponse(response, error)
-            if (xdebugResponse) {
-                this._checkStatus(xdebugResponse)
-            }
-            return
-        }
         response.body = {
             allThreadsContinued: false,
         }
-        this.sendResponse(response)
-        this._checkStatus(xdebugResponse)
-    }
-
-    protected async nextRequest(response: VSCodeDebugProtocol.NextResponse, args: VSCodeDebugProtocol.NextArguments) {
-        let xdebugResponse: xdebug.StatusResponse | undefined
-        try {
-            const connection = this._connections.get(args.threadId)
-            if (!connection) {
-                throw new Error('Unknown thread ID ' + args.threadId)
-            }
-            xdebugResponse = await connection.sendStepOverCommand()
-        } catch (error) {
-            this.sendErrorResponse(response, error)
-            if (xdebugResponse) {
-                this._checkStatus(xdebugResponse)
-            }
+        const connection = this._connections.get(args.threadId)
+        if (!connection) {
+            this.sendErrorResponse(response, new Error('Unkown thread ID ' + args.threadId))
             return
         }
         this.sendResponse(response)
-        this._checkStatus(xdebugResponse)
+        this._checkStatus(await connection.sendRunCommand())
+    }
+
+    protected async nextRequest(response: VSCodeDebugProtocol.NextResponse, args: VSCodeDebugProtocol.NextArguments) {
+        const connection = this._connections.get(args.threadId)
+        if (!connection) {
+            this.sendErrorResponse(response, new Error('Unkown thread ID ' + args.threadId))
+            return
+        }
+        this.sendResponse(response)
+        this._checkStatus(await connection.sendStepOverCommand())
     }
 
     protected async stepInRequest(
         response: VSCodeDebugProtocol.StepInResponse,
         args: VSCodeDebugProtocol.StepInArguments
     ) {
-        let xdebugResponse: xdebug.StatusResponse | undefined
-        try {
-            const connection = this._connections.get(args.threadId)
-            if (!connection) {
-                throw new Error('Unknown thread ID ' + args.threadId)
-            }
-            xdebugResponse = await connection.sendStepIntoCommand()
-        } catch (error) {
-            this.sendErrorResponse(response, error)
-            if (xdebugResponse) {
-                this._checkStatus(xdebugResponse)
-            }
+        const connection = this._connections.get(args.threadId)
+        if (!connection) {
+            this.sendErrorResponse(response, new Error('Unkown thread ID ' + args.threadId))
             return
         }
         this.sendResponse(response)
-        this._checkStatus(xdebugResponse)
+        this._checkStatus(await connection.sendStepIntoCommand())
     }
 
     protected async stepOutRequest(
         response: VSCodeDebugProtocol.StepOutResponse,
         args: VSCodeDebugProtocol.StepOutArguments
     ) {
-        let xdebugResponse: xdebug.StatusResponse | undefined
-        try {
-            const connection = this._connections.get(args.threadId)
-            if (!connection) {
-                throw new Error('Unknown thread ID ' + args.threadId)
-            }
-            xdebugResponse = await connection.sendStepOutCommand()
-        } catch (error) {
-            this.sendErrorResponse(response, error)
-            if (xdebugResponse) {
-                this._checkStatus(xdebugResponse)
-            }
+        const connection = this._connections.get(args.threadId)
+        if (!connection) {
+            this.sendErrorResponse(response, new Error('Unkown thread ID ' + args.threadId))
             return
         }
         this.sendResponse(response)
-        this._checkStatus(xdebugResponse)
+        this._checkStatus(await connection.sendStepOutCommand())
     }
 
     protected pauseRequest(response: VSCodeDebugProtocol.PauseResponse, args: VSCodeDebugProtocol.PauseArguments) {
@@ -981,6 +945,7 @@ class PhpDebugSession extends vscode.DebugSession {
         response: VSCodeDebugProtocol.DisconnectResponse,
         args: VSCodeDebugProtocol.DisconnectArguments
     ) {
+        this.sendResponse(response)
         try {
             await Promise.all(
                 Array.from(this._connections).map(async ([id, connection]) => {
@@ -1004,7 +969,6 @@ class PhpDebugSession extends vscode.DebugSession {
             this.sendErrorResponse(response, error)
             return
         }
-        this.sendResponse(response)
         this.shutdown()
     }
 


### PR DESCRIPTION
If you click next or continue and the PHP code is taking a while to run, it seems like the button did not have an effect because the context still shows and it still appears to be paused.  The only hint that it worked, is that if you try to interact with the context, or eval any code in the console, it won't work because it has actually continued.

Looking at the docs for the continue, step into, etc. events, they indicate that it should actually send the response right away indicating that the action has started.  Then after the action is complete, send the appropriate stop event depending on if it is now stopped on breakpoint etc.

But the way it was before, it did not do this, it waited until the next pause point before sending both the initial response and the one run after it is done.  This was causing the UI to hang as described above.

Here is the applicable reference documentation I relied on when making this change:

https://github.com/Microsoft/vscode-debugadapter-node/blob/750f50bc875669fe3cb7594804bcfc6326b27d0e/protocol/src/debugProtocol.ts#L559

> The debug adapter **first** sends the response **and then** a 'stopped' event (with reason 'step') **after the step has completed**.

(my emphasis added)

Relates to #307 #301 