### PR TITLE
feat: Add support for Logpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.17.0]
+
+## Added
+
+- Added logpoint support.
+
 ## [1.16.3]
 
 ## Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -7212,6 +7212,11 @@
         "readable-stream": "^2.0.2"
       }
     },
+    "string-replace-async": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/string-replace-async/-/string-replace-async-2.0.0.tgz",
+      "integrity": "sha512-AHMupZscUiDh07F1QziX7PLoB1DQ/pzu19vc8Xa8LwZcgnOXaw7yCgBuSYrxVEfaM2d8scc3Gtp+i+QJZV+spw=="
+    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "minimatch": "^3.0.4",
     "moment": "^2.29.1",
     "relateurl": "^0.2.7",
+    "string-replace-async": "^1.2.1",
     "url-relative": "^1.0.0",
     "urlencode": "^1.1.0",
     "vscode-debugadapter": "^1.47.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "minimatch": "^3.0.4",
     "moment": "^2.29.1",
     "relateurl": "^0.2.7",
-    "string-replace-async": "^1.2.1",
+    "string-replace-async": "^2.0.0",
     "url-relative": "^1.0.0",
     "urlencode": "^1.1.0",
     "vscode-debugadapter": "^1.47.0",

--- a/src/logpoint.ts
+++ b/src/logpoint.ts
@@ -1,0 +1,32 @@
+import stringReplaceAsync = require('string-replace-async')
+
+export class LogPointManager {
+    private _logpoints = new Map<string, Map<number, string>>()
+
+    public addLogPoint(fileUri: string, lineNumber: number, logMessage: string) {
+        if (!this._logpoints.has(fileUri)) {
+            this._logpoints.set(fileUri, new Map<number, string>())
+        }
+        this._logpoints.get(fileUri)!.set(lineNumber, logMessage)
+    }
+
+    public clearFromFile(fileUri: string) {
+        if (this._logpoints.has(fileUri)) {
+            this._logpoints.get(fileUri)!.clear()
+        }
+    }
+
+    public hasLogPoint(fileUri: string, lineNumber: number): boolean {
+        return this._logpoints.has(fileUri) && this._logpoints.get(fileUri)!.has(lineNumber);
+    }
+
+    public async resolveExpressions(fileUri: string, lineNumber: number, callback: (expr: string) => Promise<string>): Promise<string> {
+        if(!this.hasLogPoint(fileUri, lineNumber)) {
+            return Promise.reject('Logpoint not found')
+        }
+        const expressionRegex = /\{(.*?)\}/gm
+        return await stringReplaceAsync(this._logpoints.get(fileUri)!.get(lineNumber), expressionRegex, function(_: string, group: string) {
+            return callback(group);
+        });
+    }
+}

--- a/src/logpoint.ts
+++ b/src/logpoint.ts
@@ -1,9 +1,13 @@
 import stringReplaceAsync = require('string-replace-async')
+import { isWindowsUri } from './paths'
 
 export class LogPointManager {
     private _logpoints = new Map<string, Map<number, string>>()
 
     public addLogPoint(fileUri: string, lineNumber: number, logMessage: string) {
+        if (isWindowsUri(fileUri)) {
+            fileUri = fileUri.toLowerCase()
+        }
         if (!this._logpoints.has(fileUri)) {
             this._logpoints.set(fileUri, new Map<number, string>())
         }
@@ -11,22 +15,39 @@ export class LogPointManager {
     }
 
     public clearFromFile(fileUri: string) {
+        if (isWindowsUri(fileUri)) {
+            fileUri = fileUri.toLowerCase()
+        }
         if (this._logpoints.has(fileUri)) {
             this._logpoints.get(fileUri)!.clear()
         }
     }
 
     public hasLogPoint(fileUri: string, lineNumber: number): boolean {
-        return this._logpoints.has(fileUri) && this._logpoints.get(fileUri)!.has(lineNumber);
+        if (isWindowsUri(fileUri)) {
+            fileUri = fileUri.toLowerCase()
+        }
+        return this._logpoints.has(fileUri) && this._logpoints.get(fileUri)!.has(lineNumber)
     }
 
-    public async resolveExpressions(fileUri: string, lineNumber: number, callback: (expr: string) => Promise<string>): Promise<string> {
-        if(!this.hasLogPoint(fileUri, lineNumber)) {
+    public async resolveExpressions(
+        fileUri: string,
+        lineNumber: number,
+        callback: (expr: string) => Promise<string>
+    ): Promise<string> {
+        if (isWindowsUri(fileUri)) {
+            fileUri = fileUri.toLowerCase()
+        }
+        if (!this.hasLogPoint(fileUri, lineNumber)) {
             return Promise.reject('Logpoint not found')
         }
         const expressionRegex = /\{(.*?)\}/gm
-        return await stringReplaceAsync(this._logpoints.get(fileUri)!.get(lineNumber), expressionRegex, function(_: string, group: string) {
-            return callback(group);
-        });
+        return await stringReplaceAsync(
+            this._logpoints.get(fileUri)!.get(lineNumber)!,
+            expressionRegex,
+            function (_: string, group: string) {
+                return group.length === 0 ? Promise.resolve('') : callback(group)
+            }
+        )
     }
 }

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -141,7 +141,7 @@ export function convertClientPathToDebugger(localPath: string, pathMapping?: { [
     return serverFileUri
 }
 
-function isWindowsUri(path: string): boolean {
+export function isWindowsUri(path: string): boolean {
     return /^file:\/\/\/[a-zA-Z]:\//.test(path)
 }
 

--- a/src/test/logpoint.ts
+++ b/src/test/logpoint.ts
@@ -1,0 +1,98 @@
+import { LogPointManager } from '../logpoint'
+import * as assert from 'assert'
+
+describe('logpoint', () => {
+    const FILE_URI1 = 'file://my/file1'
+    const FILE_URI2 = 'file://my/file2'
+    const FILE_URI3 = 'file://my/file3'
+
+    const LOG_MESSAGE_VAR = '{$variable1}'
+    const LOG_MESSAGE_MULTIPLE = '{$variable1} {$variable3} {$variable2}'
+    const LOG_MESSAGE_TEXT_AND_VAR = 'This is my {$variable1}'
+    const LOG_MESSAGE_TEXT_AND_MULTIVAR = 'Those variables: {$variable1} ${$variable2} should be replaced'
+    const LOG_MESSAGE_REPEATED_VAR = 'This {$variable1} and {$variable1} should be equal'
+    const LOG_MESSAGE_BADLY_FORMATED_VAR = 'Only {$variable1} should be resolved and not }$variable1 and $variable1{}'
+
+    const REPLACE_FUNCTION = (str: string): Promise<string> => {
+        return Promise.resolve(`${str}_value`)
+    }
+
+    let logPointManager: LogPointManager
+
+    beforeEach('create new instance', () => (logPointManager = new LogPointManager()))
+
+    describe('basic map management', () => {
+        it('should contain added logpoints', () => {
+            logPointManager.addLogPoint(FILE_URI1, 10, LOG_MESSAGE_VAR)
+            logPointManager.addLogPoint(FILE_URI1, 11, LOG_MESSAGE_VAR)
+            logPointManager.addLogPoint(FILE_URI2, 12, LOG_MESSAGE_VAR)
+            logPointManager.addLogPoint(FILE_URI3, 13, LOG_MESSAGE_VAR)
+
+            assert.equal(logPointManager.hasLogPoint(FILE_URI1, 10), true)
+            assert.equal(logPointManager.hasLogPoint(FILE_URI1, 11), true)
+            assert.equal(logPointManager.hasLogPoint(FILE_URI2, 12), true)
+            assert.equal(logPointManager.hasLogPoint(FILE_URI3, 13), true)
+
+            assert.equal(logPointManager.hasLogPoint(FILE_URI1, 12), false)
+            assert.equal(logPointManager.hasLogPoint(FILE_URI2, 13), false)
+            assert.equal(logPointManager.hasLogPoint(FILE_URI3, 10), false)
+        })
+
+        it('should add and clear entries', () => {
+            logPointManager.addLogPoint(FILE_URI1, 10, LOG_MESSAGE_VAR)
+            logPointManager.addLogPoint(FILE_URI1, 11, LOG_MESSAGE_VAR)
+            logPointManager.addLogPoint(FILE_URI2, 12, LOG_MESSAGE_VAR)
+            logPointManager.addLogPoint(FILE_URI3, 13, LOG_MESSAGE_VAR)
+
+            assert.equal(logPointManager.hasLogPoint(FILE_URI1, 10), true)
+            assert.equal(logPointManager.hasLogPoint(FILE_URI1, 11), true)
+            assert.equal(logPointManager.hasLogPoint(FILE_URI2, 12), true)
+            assert.equal(logPointManager.hasLogPoint(FILE_URI3, 13), true)
+
+            logPointManager.clearFromFile(FILE_URI1)
+
+            assert.equal(logPointManager.hasLogPoint(FILE_URI1, 10), false)
+            assert.equal(logPointManager.hasLogPoint(FILE_URI1, 11), false)
+            assert.equal(logPointManager.hasLogPoint(FILE_URI2, 12), true)
+            assert.equal(logPointManager.hasLogPoint(FILE_URI3, 13), true)
+        })
+    })
+
+    describe('variable resolution', () => {
+        it('should resolve variables', async () => {
+            logPointManager.addLogPoint(FILE_URI1, 10, LOG_MESSAGE_VAR)
+            const result = await logPointManager.resolveExpressions(FILE_URI1, 10, REPLACE_FUNCTION)
+            assert.equal(result, '$variable1_value')
+        })
+
+        it('should resolve multiple variables', async () => {
+            logPointManager.addLogPoint(FILE_URI1, 10, LOG_MESSAGE_MULTIPLE)
+            const result = await logPointManager.resolveExpressions(FILE_URI1, 10, REPLACE_FUNCTION)
+            assert.equal(result, '$variable1_value $variable3_value $variable2_value')
+        })
+
+        it('should resolve variables with text', async () => {
+            logPointManager.addLogPoint(FILE_URI1, 10, LOG_MESSAGE_TEXT_AND_VAR)
+            const result = await logPointManager.resolveExpressions(FILE_URI1, 10, REPLACE_FUNCTION)
+            assert.equal(result, 'This is my $variable1_value')
+        })
+
+        it('should resolve multiple variables with text', async () => {
+            logPointManager.addLogPoint(FILE_URI1, 10, LOG_MESSAGE_TEXT_AND_MULTIVAR)
+            const result = await logPointManager.resolveExpressions(FILE_URI1, 10, REPLACE_FUNCTION)
+            assert.equal(result, 'Those variables: $variable1_value $$variable2_value should be replaced')
+        })
+
+        it('should resolve repeated variables', async () => {
+            logPointManager.addLogPoint(FILE_URI1, 10, LOG_MESSAGE_REPEATED_VAR)
+            const result = await logPointManager.resolveExpressions(FILE_URI1, 10, REPLACE_FUNCTION)
+            assert.equal(result, 'This $variable1_value and $variable1_value should be equal')
+        })
+
+        it('should resolve repeated bad formated messages correctly', async () => {
+            logPointManager.addLogPoint(FILE_URI1, 10, LOG_MESSAGE_BADLY_FORMATED_VAR)
+            const result = await logPointManager.resolveExpressions(FILE_URI1, 10, REPLACE_FUNCTION)
+            assert.equal(result, 'Only $variable1_value should be resolved and not }$variable1 and $variable1')
+        })
+    })
+})


### PR DESCRIPTION
Added support to logpoints. I have very limited knowledge about XDebug protocol, but I believe it does not support anything like the logpoint feature from VSCode. 
So I thought about doing the following:
* add a regular breakpoint
* when breakpoint hit:
  * parse message
    * send eval command to xdebug for each expression inside curly brackets
   * send output to vscode console
   * send continue event

closes #258 