### PR TITLE
fix: Extension not exporting activate function (#346)

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "bugs": {
     "url": "https://github.com/felixfbecker/vscode-php-debug/issues"
   },
+  "main": "./out/extension",
   "dependencies": {
     "file-url": "^2.0.0",
     "iconv-lite": "^0.4.15",


### PR DESCRIPTION
The fix adds `main` attribute to `package.json` thus making it to be treated an an extension.

Signed-off-by: Victor Rubezhny <vrubezhny@redhat.com>