### PR TITLE
Fix case: XDebug -> Xdebug

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,8 +45,8 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           extensions: ${{ matrix.xdebug }}
-          # Top: XDebug v3
-          # Bottom: XDebug v2
+          # Top: Xdebug v3
+          # Bottom: Xdebug v2
           ini-values: >-
             xdebug.mode = debug,
             xdebug.start_with_request = yes,

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,11 +1,11 @@
-PHP version:  
-XDebug version:  
+PHP version:
+Xdebug version:
 Adapter version:
 
-Your launch.json:  
-XDebug php.ini config:
+Your launch.json:
+Xdebug php.ini config:
 
-XDebug logfile (from setting `xdebug.remote_log` in php.ini):  
+Xdebug logfile (from setting `xdebug.remote_log` in php.ini):
 Adapter logfile (from setting `"log": true` in launch.json):
 
 Code snippet to reproduce:

--- a/README.md
+++ b/README.md
@@ -46,20 +46,20 @@ This extension is a debug adapter between VS Code and [Xdebug](https://xdebug.or
 In your project, go to the debugger and hit the little gear icon and choose _PHP_. A new launch configuration will be created for you with two configurations:
 
 - **Listen for Xdebug**
-  This setting will simply start listening on the specified port (by default 9000) for XDebug. If you configured XDebug like recommended above, everytime you make a request with a browser to your webserver or launch a CLI script Xdebug will connect and you can stop on breakpoints, exceptions etc.
+  This setting will simply start listening on the specified port (by default 9000) for Xdebug. If you configured Xdebug like recommended above, everytime you make a request with a browser to your webserver or launch a CLI script Xdebug will connect and you can stop on breakpoints, exceptions etc.
 - **Launch currently open script**
   This setting is an example of CLI debugging. It will launch the currently opened script as a CLI, show all stdout/stderr output in the debug console and end the debug session once the script exits.
 
 #### Supported launch.json settings:
 
 - `request`: Always `"launch"`
-- `hostname`: The address to bind to when listening for XDebug (default: all IPv6 connections if available, else all IPv4 connections)
+- `hostname`: The address to bind to when listening for Xdebug (default: all IPv6 connections if available, else all IPv4 connections)
 - `port`: The port on which to listen for Xdebug (default: `9000`)
 - `stopOnEntry`: Whether to break at the beginning of the script (default: `false`)
 - `pathMappings`: A list of server paths mapping to the local source paths on your machine, see "Remote Host Debugging" below
 - `log`: Whether to log all communication between VS Code and the adapter to the debug console. See _Troubleshooting_ further down.
 - `ignore`: An optional array of glob patterns that errors should be ignored from (for example `**/vendor/**/*.php`)
-- `xdebugSettings`: Allows you to override XDebug's remote debugging settings to fine tuning XDebug to your needs. For example, you can play with `max_children` and `max_depth` to change the max number of array and object children that are retrieved and the max depth in structures like arrays and objects. This can speed up the debugger on slow machines.
+- `xdebugSettings`: Allows you to override Xdebug's remote debugging settings to fine tuning Xdebug to your needs. For example, you can play with `max_children` and `max_depth` to change the max number of array and object children that are retrieved and the max depth in structures like arrays and objects. This can speed up the debugger on slow machines.
   For a full list of feature names that can be set please refer to the [Xdebug documentation](https://xdebug.org/docs-dbgp.php#feature-names).
   - `max_children`: max number of array or object children to initially retrieve
   - `max_data`: max amount of variable data to initially retrieve.
@@ -132,4 +132,4 @@ VS Code will open an "Extension Development Host" with the debug adapter running
 
 The extension is written in TypeScript. You can compile it through `npm run build`. `npm run watch` enables incremental compilation.
 
-Tests are written with Mocha and can be run with `npm test`. The tests are run in CI on Linux, macOS and Windows against multiple PHP and XDebug versions.
+Tests are written with Mocha and can be run with `npm test`. The tests are run in CI on Linux, macOS and Windows against multiple PHP and Xdebug versions.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0-development",
   "publisher": "felixfbecker",
   "license": "MIT",
-  "description": "Debug support for PHP with XDebug",
+  "description": "Debug support for PHP with Xdebug",
   "keywords": [
     "php",
     "debug",
@@ -196,12 +196,12 @@
               },
               "hostname": {
                 "type": "string",
-                "description": "Address to bind to when listening for XDebug",
+                "description": "Address to bind to when listening for Xdebug",
                 "default": "::"
               },
               "port": {
                 "type": "number",
-                "description": "Port on which to listen for XDebug",
+                "description": "Port on which to listen for Xdebug",
                 "default": 9000
               },
               "serverSourceRoot": {
@@ -250,7 +250,7 @@
                     "description": "This feature can get set by the IDE if it wants to have more detailed internal information on properties (eg. private members of classes, etc.) Zero means that hidden members are not shown to the IDE"
                   }
                 },
-                "description": "Overrides for XDebug remote debugging settings. See https://xdebug.org/docs-dbgp.php#feature-names",
+                "description": "Overrides for Xdebug remote debugging settings. See https://xdebug.org/docs-dbgp.php#feature-names",
                 "default": {}
               }
             }
@@ -258,7 +258,7 @@
         },
         "initialConfigurations": [
           {
-            "name": "Listen for XDebug",
+            "name": "Listen for Xdebug",
             "type": "php",
             "request": "launch",
             "port": 9000

--- a/src/dbgp.ts
+++ b/src/dbgp.ts
@@ -3,7 +3,7 @@ import { EventEmitter } from 'events'
 import * as iconv from 'iconv-lite'
 import { DOMParser } from 'xmldom'
 
-/** The encoding all XDebug messages are encoded with */
+/** The encoding all Xdebug messages are encoded with */
 export const ENCODING = 'iso-8859-1'
 
 /** The two states the connection switches between */

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -23,7 +23,7 @@ const RELATE_URL_OPTIONS: RelateUrl.Options = {
  */
 const relativeUrl = (from: string, to: string): string => RelateUrl.relate(from, to, RELATE_URL_OPTIONS)
 
-/** converts a server-side XDebug file URI to a local path for VS Code with respect to source root settings */
+/** converts a server-side Xdebug file URI to a local path for VS Code with respect to source root settings */
 export function convertDebuggerPathToClient(
     fileUri: string | url.Url,
     pathMapping?: { [index: string]: string }
@@ -71,11 +71,11 @@ export function convertDebuggerPathToClient(
     return localPath
 }
 
-/** converts a local path from VS Code to a server-side XDebug file URI with respect to source root settings */
+/** converts a local path from VS Code to a server-side Xdebug file URI with respect to source root settings */
 export function convertClientPathToDebugger(localPath: string, pathMapping?: { [index: string]: string }): string {
     let localSourceRoot: string | undefined
     let serverSourceRoot: string | undefined
-    // XDebug always lowercases Windows drive letters in file URIs
+    // Xdebug always lowercases Windows drive letters in file URIs
     let localFileUri = fileUrl(
         localPath.replace(/^[A-Z]:\\/, match => match.toLowerCase()),
         { resolve: false }

--- a/src/test/adapter.ts
+++ b/src/test/adapter.ts
@@ -389,7 +389,7 @@ describe('PHP Debug Adapter', () => {
             const scopes = (await client.scopesRequest({ frameId: stackFrame.id })).body.scopes
             localScope = scopes.find(scope => scope.name === 'Locals')
             superglobalsScope = scopes.find(scope => scope.name === 'Superglobals')
-            constantsScope = scopes.find(scope => scope.name === 'User defined constants') // XDebug >2.3 only
+            constantsScope = scopes.find(scope => scope.name === 'User defined constants') // Xdebug >2.3 only
         })
 
         it('should report scopes correctly', () => {

--- a/src/xdebugConnection.ts
+++ b/src/xdebugConnection.ts
@@ -2,10 +2,10 @@ import * as net from 'net'
 import * as iconv from 'iconv-lite'
 import { DbgpConnection } from './dbgp'
 
-/** The encoding all XDebug messages are encoded with */
+/** The encoding all Xdebug messages are encoded with */
 const ENCODING = 'iso-8859-1'
 
-/** The first packet we receive from XDebug. Returned by waitForInitPacket() */
+/** The first packet we receive from Xdebug. Returned by waitForInitPacket() */
 export class InitPacket {
     /** The file that was requested as a file:// URI */
     fileUri: string
@@ -17,7 +17,7 @@ export class InitPacket {
     ideKey: string
     /** a reference to the connection this packet was received from */
     connection: Connection
-    /** the version of XDebug */
+    /** the version of Xdebug */
     engineVersion: string
     /**
      * @param  {XMLDocument} document - An XML document to read from
@@ -34,18 +34,18 @@ export class InitPacket {
     }
 }
 
-/** Error class for errors returned from XDebug */
-export class XDebugError extends Error {
+/** Error class for errors returned from Xdebug */
+export class XdebugError extends Error {
     code: number
     constructor(message: string, code: number) {
         super(message)
         this.code = code
         this.message = message
-        this.name = 'XDebugError'
+        this.name = 'XdebugError'
     }
 }
 
-/** The base class for all XDebug responses to commands executed on a connection */
+/** The base class for all Xdebug responses to commands executed on a connection */
 export class Response {
     /** A unique transaction ID that matches the one in the request */
     transactionId: number
@@ -65,7 +65,7 @@ export class Response {
             const errorNode = <Element>documentElement.firstChild
             const code = parseInt(errorNode.getAttribute('code')!)
             const message = errorNode.textContent!
-            throw new XDebugError(message, code)
+            throw new XdebugError(message, code)
         }
         this.transactionId = parseInt(documentElement.getAttribute('transaction_id')!)
         this.command = documentElement.getAttribute('command')!
@@ -143,7 +143,7 @@ export abstract class Breakpoint {
                 throw new Error(`Invalid type ${breakpointNode.getAttribute('type')}`)
         }
     }
-    /** Constructs a breakpoint object from an XML node from a XDebug response */
+    /** Constructs a breakpoint object from an XML node from a Xdebug response */
     constructor(breakpointNode: Element, connection: Connection)
     /** To create a new breakpoint in derived classes */
     constructor(type: BreakpointType)
@@ -221,7 +221,7 @@ export class CallBreakpoint extends Breakpoint {
 export class ExceptionBreakpoint extends Breakpoint {
     /** The Exception name to break on. Can also contain wildcards. */
     exception: string
-    /** Constructs a breakpoint object from an XML node from a XDebug response */
+    /** Constructs a breakpoint object from an XML node from a Xdebug response */
     constructor(breakpointNode: Element, connection: Connection)
     /** Constructs a breakpoint for passing it to sendSetBreakpointCommand */
     constructor(exception: string)
@@ -248,7 +248,7 @@ export class ConditionalBreakpoint extends Breakpoint {
     line: number
     /** The PHP expression under which to break on */
     expression: string
-    /** Constructs a breakpoint object from an XML node from a XDebug response */
+    /** Constructs a breakpoint object from an XML node from a Xdebug response */
     constructor(breakpointNode: Element, connection: Connection)
     /** Contructs a breakpoint object for passing to sendSetBreakpointCommand */
     constructor(expression: string, fileUri: string, line?: number)
@@ -550,7 +550,7 @@ interface Command {
 }
 
 /**
- * This class represents a connection to XDebug and is instantiated with a socket.
+ * This class represents a connection to Xdebug and is instantiated with a socket.
  */
 export class Connection extends DbgpConnection {
     /** a counter for unique connection IDs */
@@ -575,15 +575,15 @@ export class Connection extends DbgpConnection {
     private _initPromiseRejectFn: (err?: Error) => any
 
     /**
-     * a map from transaction IDs to pending commands that have been sent to XDebug and are awaiting a response.
+     * a map from transaction IDs to pending commands that have been sent to Xdebug and are awaiting a response.
      * This should in theory only contain max one element at any time.
      */
     private _pendingCommands = new Map<number, Command>()
 
     /**
-     * XDebug does NOT support async communication.
+     * Xdebug does NOT support async communication.
      * This means before sending a new command, we have to wait until we get a response for the previous.
-     * This array is a stack of commands that get passed to _sendCommand once XDebug can accept commands again.
+     * This array is a stack of commands that get passed to _sendCommand once Xdebug can accept commands again.
      */
     private _commandQueue: Command[] = []
 
@@ -596,7 +596,7 @@ export class Connection extends DbgpConnection {
         return this._pendingExecuteCommand
     }
 
-    /** Constructs a new connection that uses the given socket to communicate with XDebug. */
+    /** Constructs a new connection that uses the given socket to communicate with Xdebug. */
     constructor(socket: net.Socket) {
         super(socket)
         this.id = Connection._connectionCounter++
@@ -631,7 +631,7 @@ export class Connection extends DbgpConnection {
 
     /**
      * Pushes a new command to the queue that will be executed after all the previous commands have finished and we received a response.
-     * If the queue is empty AND there are no pending transactions (meaning we already received a response and XDebug is waiting for
+     * If the queue is empty AND there are no pending transactions (meaning we already received a response and Xdebug is waiting for
      * commands) the command will be executed immediately.
      */
     private _enqueueCommand(name: string, args?: string, data?: string): Promise<XMLDocument> {
@@ -643,7 +643,7 @@ export class Connection extends DbgpConnection {
     /**
      * Pushes a new execute command (one that results in executing PHP code) to the queue that will be executed after all the previous
      * commands have finished and we received a response.
-     * If the queue is empty AND there are no pending transactions (meaning we already received a response and XDebug is waiting for
+     * If the queue is empty AND there are no pending transactions (meaning we already received a response and Xdebug is waiting for
      * commands) the command will be executed immediately.
      */
     private _enqueueExecuteCommand(name: string, args?: string, data?: string): Promise<XMLDocument> {
@@ -662,8 +662,8 @@ export class Connection extends DbgpConnection {
     }
 
     /**
-     * Sends a command to XDebug with a new transaction ID and calls the callback on the command. This can
-     * only be called when XDebug can actually accept commands, which is after we received a response for the
+     * Sends a command to Xdebug with a new transaction ID and calls the callback on the command. This can
+     * only be called when Xdebug can actually accept commands, which is after we received a response for the
      * previous command.
      */
     private async _executeCommand(command: Command): Promise<void> {

--- a/testproject/.vscode/launch.json
+++ b/testproject/.vscode/launch.json
@@ -3,7 +3,7 @@
   "configurations": [
     {
       //"debugServer": 4711, // Uncomment for debugging the adapter
-      "name": "Listen for XDebug",
+      "name": "Listen for Xdebug",
       "type": "php",
       "request": "launch",
       "port": 9000,


### PR DESCRIPTION
This is not a troll or anything, I was asking myself what's the correct way to write Xdebug and noticed that "XDebug" is mainly used is this extension. Is it intentional?

Source: https://xdebug.org/