### PR TITLE
feat: launch support auto port

### DIFF
--- a/package.json
+++ b/package.json
@@ -250,7 +250,7 @@
             "request": "launch",
             "program": "${file}",
             "cwd": "${fileDirname}",
-            "port": 9000
+            "port": 0
           }
         ]
       }


### PR DESCRIPTION
If user doesn't specify a debug port,
The script will use a free port to use.

Sometimes, user just want debug a script, and doesn't care about debug port. so, let it choose automatically.