### PR TITLE
feat: implement longest prefix matching for pathMappings (closes #331)

### DIFF
--- a/src/paths.ts
+++ b/src/paths.ts
@@ -46,9 +46,13 @@ export function convertDebuggerPathToClient(
             // normalize slashes for windows-to-unix
             const serverRelative = (serverIsWindows ? path.win32 : path.posix).relative(mappedServerPath, serverPath)
             if (serverRelative.indexOf('..') !== 0) {
-                serverSourceRoot = mappedServerPath
-                localSourceRoot = mappedLocalSource
-                break
+                // If a matching mapping has previously been found, only update
+                // it if the current server path is longer than the previous one
+                // (longest prefix matching)
+                if (!serverSourceRoot || mappedServerPath.length > serverSourceRoot.length) {
+                    serverSourceRoot = mappedServerPath
+                    localSourceRoot = mappedLocalSource
+                }
             }
         }
     }
@@ -82,9 +86,13 @@ export function convertClientPathToDebugger(localPath: string, pathMapping?: { [
             const mappedLocalSource = pathMapping[mappedServerPath]
             const localRelative = path.relative(mappedLocalSource, localPath)
             if (localRelative.indexOf('..') !== 0) {
-                serverSourceRoot = mappedServerPath
-                localSourceRoot = mappedLocalSource
-                break
+                // If a matching mapping has previously been found, only update
+                // it if the current local path is longer than the previous one
+                // (longest prefix matching)
+                if (!localSourceRoot || mappedLocalSource.length > localSourceRoot.length) {
+                    serverSourceRoot = mappedServerPath
+                    localSourceRoot = mappedLocalSource
+                }
             }
         }
     }

--- a/src/test/paths.ts
+++ b/src/test/paths.ts
@@ -55,6 +55,15 @@ describe('paths', () => {
                     }),
                     'file:///app/source.php'
                 )
+                // longest prefix matching for server paths
+                assert.strictEqual(
+                    convertClientPathToDebugger('/home/felix/mysource/subdir/source.php', {
+                        '/var/www': '/home/felix/mysite',
+                        '/app/subdir1': '/home/felix/mysource/subdir',
+                        '/app': '/home/felix/mysource',
+                    }),
+                    'file:///app/subdir1/source.php'
+                )
             })
             // unix to windows
             it('should convert a unix path to a windows URI', () => {
@@ -164,6 +173,15 @@ describe('paths', () => {
                         '/app': '/home/felix/mysource',
                     }),
                     '/home/felix/mysource/source.php'
+                )
+                // longest prefix matching for local paths
+                assert.strictEqual(
+                    convertDebuggerPathToClient('file:///app/subdir/source.php', {
+                        '/var/www': '/home/felix/mysite',
+                        '/app/subdir': '/home/felix/mysource/subdir1',
+                        '/app': '/home/felix/mysource',
+                    }),
+                    '/home/felix/mysource/subdir1/source.php'
                 )
             })
             // unix to windows


### PR DESCRIPTION
I decided to approach #331 and it turned out to be only a minor change. I also added longest prefix matching for the client to debugger mapping as there are use cases for this as well and it does not affect the existing mapping behavior (unless in actual use cases in which the change is most certainly welcome).