### PR TITLE
fix: remove current execution position when performing stop or continue dbgp operation.

### DIFF
--- a/src/phpDebug.ts
+++ b/src/phpDebug.ts
@@ -894,9 +894,9 @@ class PhpDebugSession extends vscode.DebugSession {
         response: VSCodeDebugProtocol.ContinueResponse,
         args: VSCodeDebugProtocol.ContinueArguments
     ) {
-        let xdebugResponse: xdebug.StatusResponse | undefined
+        let connection: xdebug.Connection | undefined
         try {
-            const connection = this._connections.get(args.threadId)
+            connection = this._connections.get(args.threadId)
             if (!connection) {
                 return this.sendErrorResponse(response, new Error('Unknown thread ID ' + args.threadId))
             }
@@ -904,74 +904,96 @@ class PhpDebugSession extends vscode.DebugSession {
                 allThreadsContinued: false,
             }
             this.sendResponse(response)
-            xdebugResponse = await connection.sendRunCommand()
         } catch (error) {
-            if (xdebugResponse) {
-                this._checkStatus(xdebugResponse)
-            }
+            this.sendErrorResponse(response, error)
             return
         }
-        this._checkStatus(xdebugResponse)
+        try {
+            const xdebugResponse = await connection.sendRunCommand()
+            this._checkStatus(xdebugResponse)
+        } catch (error) {
+            this.sendEvent(
+                new vscode.OutputEvent(
+                    'continueRequest thread ID ' + args.threadId + ' error: ' + error.message + '\n'
+                ),
+                true
+            )
+        }
     }
 
     protected async nextRequest(response: VSCodeDebugProtocol.NextResponse, args: VSCodeDebugProtocol.NextArguments) {
-        let xdebugResponse: xdebug.StatusResponse | undefined
+        let connection: xdebug.Connection | undefined
         try {
-            const connection = this._connections.get(args.threadId)
+            connection = this._connections.get(args.threadId)
             if (!connection) {
                 return this.sendErrorResponse(response, new Error('Unknown thread ID ' + args.threadId))
             }
             this.sendResponse(response)
-            xdebugResponse = await connection.sendStepOverCommand()
         } catch (error) {
-            if (xdebugResponse) {
-                this._checkStatus(xdebugResponse)
-            }
+            this.sendErrorResponse(response, error)
             return
         }
-        this._checkStatus(xdebugResponse)
+        try {
+            const xdebugResponse = await connection.sendStepOverCommand()
+            this._checkStatus(xdebugResponse)
+        } catch (error) {
+            this.sendEvent(
+                new vscode.OutputEvent('nextRequest thread ID ' + args.threadId + ' error: ' + error.message + '\n'),
+                true
+            )
+        }
     }
 
     protected async stepInRequest(
         response: VSCodeDebugProtocol.StepInResponse,
         args: VSCodeDebugProtocol.StepInArguments
     ) {
-        let xdebugResponse: xdebug.StatusResponse | undefined
+        let connection: xdebug.Connection | undefined
         try {
-            const connection = this._connections.get(args.threadId)
+            connection = this._connections.get(args.threadId)
             if (!connection) {
                 return this.sendErrorResponse(response, new Error('Unknown thread ID ' + args.threadId))
             }
             this.sendResponse(response)
-            xdebugResponse = await connection.sendStepIntoCommand()
         } catch (error) {
-            if (xdebugResponse) {
-                this._checkStatus(xdebugResponse)
-            }
+            this.sendErrorResponse(response, error)
             return
         }
-        this._checkStatus(xdebugResponse)
+        try {
+            const xdebugResponse = await connection.sendStepIntoCommand()
+            this._checkStatus(xdebugResponse)
+        } catch (error) {
+            this.sendEvent(
+                new vscode.OutputEvent('stepInRequest thread ID ' + args.threadId + ' error: ' + error.message + '\n'),
+                true
+            )
+        }
     }
 
     protected async stepOutRequest(
         response: VSCodeDebugProtocol.StepOutResponse,
         args: VSCodeDebugProtocol.StepOutArguments
     ) {
-        let xdebugResponse: xdebug.StatusResponse | undefined
+        let connection: xdebug.Connection | undefined
         try {
-            const connection = this._connections.get(args.threadId)
+            connection = this._connections.get(args.threadId)
             if (!connection) {
                 return this.sendErrorResponse(response, new Error('Unknown thread ID ' + args.threadId))
             }
             this.sendResponse(response)
-            xdebugResponse = await connection.sendStepOutCommand()
         } catch (error) {
-            if (xdebugResponse) {
-                this._checkStatus(xdebugResponse)
-            }
+            this.sendErrorResponse(response, error)
             return
         }
-        this._checkStatus(xdebugResponse)
+        try {
+            const xdebugResponse = await connection.sendStepOutCommand()
+            this._checkStatus(xdebugResponse)
+        } catch (error) {
+            this.sendEvent(
+                new vscode.OutputEvent('stepOutRequest thread ID ' + args.threadId + ' error: ' + error.message + '\n'),
+                true
+            )
+        }
     }
 
     protected pauseRequest(response: VSCodeDebugProtocol.PauseResponse, args: VSCodeDebugProtocol.PauseArguments) {

--- a/src/phpDebug.ts
+++ b/src/phpDebug.ts
@@ -898,20 +898,19 @@ class PhpDebugSession extends vscode.DebugSession {
         try {
             const connection = this._connections.get(args.threadId)
             if (!connection) {
-                throw new Error('Unknown thread ID ' + args.threadId)
+                return this.sendErrorResponse(response, new Error('Unknown thread ID ' + args.threadId))
             }
+            response.body = {
+                allThreadsContinued: false,
+            }
+            this.sendResponse(response)
             xdebugResponse = await connection.sendRunCommand()
         } catch (error) {
-            this.sendErrorResponse(response, error)
             if (xdebugResponse) {
                 this._checkStatus(xdebugResponse)
             }
             return
         }
-        response.body = {
-            allThreadsContinued: false,
-        }
-        this.sendResponse(response)
         this._checkStatus(xdebugResponse)
     }
 
@@ -920,17 +919,16 @@ class PhpDebugSession extends vscode.DebugSession {
         try {
             const connection = this._connections.get(args.threadId)
             if (!connection) {
-                throw new Error('Unknown thread ID ' + args.threadId)
+                return this.sendErrorResponse(response, new Error('Unknown thread ID ' + args.threadId))
             }
+            this.sendResponse(response)
             xdebugResponse = await connection.sendStepOverCommand()
         } catch (error) {
-            this.sendErrorResponse(response, error)
             if (xdebugResponse) {
                 this._checkStatus(xdebugResponse)
             }
             return
         }
-        this.sendResponse(response)
         this._checkStatus(xdebugResponse)
     }
 
@@ -942,17 +940,16 @@ class PhpDebugSession extends vscode.DebugSession {
         try {
             const connection = this._connections.get(args.threadId)
             if (!connection) {
-                throw new Error('Unknown thread ID ' + args.threadId)
+                return this.sendErrorResponse(response, new Error('Unknown thread ID ' + args.threadId))
             }
+            this.sendResponse(response)
             xdebugResponse = await connection.sendStepIntoCommand()
         } catch (error) {
-            this.sendErrorResponse(response, error)
             if (xdebugResponse) {
                 this._checkStatus(xdebugResponse)
             }
             return
         }
-        this.sendResponse(response)
         this._checkStatus(xdebugResponse)
     }
 
@@ -964,17 +961,16 @@ class PhpDebugSession extends vscode.DebugSession {
         try {
             const connection = this._connections.get(args.threadId)
             if (!connection) {
-                throw new Error('Unknown thread ID ' + args.threadId)
+                return this.sendErrorResponse(response, new Error('Unknown thread ID ' + args.threadId))
             }
+            this.sendResponse(response)
             xdebugResponse = await connection.sendStepOutCommand()
         } catch (error) {
-            this.sendErrorResponse(response, error)
             if (xdebugResponse) {
                 this._checkStatus(xdebugResponse)
             }
             return
         }
-        this.sendResponse(response)
         this._checkStatus(xdebugResponse)
     }
 


### PR DESCRIPTION
When the IDE requests a continue operation (step in, out, over, continue) it expects a Response and will remove the current execution position. With XDebug/DBGp the TCP connection will not send a response until another stop condition is encountered this may take an arbitrary amount of time.
This change fixes this by doing some basic validation (is the threadId valid) and then sends a response before executing the continuation command.

Closes #358