### PR TITLE
feat: alternative source file extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ In your project, go to the debugger and hit the little gear icon and choose _PHP
 - `port`: The port on which to listen for XDebug (default: `9000`)
 - `stopOnEntry`: Wether to break at the beginning of the script (default: `false`)
 - `pathMappings`: A list of server paths mapping to the local source paths on your machine, see "Remote Host Debugging" below
-- `srcExtensions`: Alternative file extensions to try if the source file does not exist. See "Alternative Source File Extensions"
 - `log`: Wether to log all communication between VS Code and the adapter to the debug console. See _Troubleshooting_ further down.
 - `ignore`: An optional array of glob patterns that errors should be ignored from (for example `**/vendor/**/*.php`)
 - `xdebugSettings`: Allows you to override XDebug's remote debugging settings to fine tuning XDebug to your needs. For example, you can play with `max_children` and `max_depth` to change the max number of array and object children that are retrieved and the max depth in structures like arrays and objects. This can speed up the debugger on slow machines.
@@ -97,18 +96,6 @@ To make VS Code map the files on the server to the right files on your local mac
   "/var/www/html": "${workspaceRoot}/www",
   "/app": "${workspaceRoot}/app"
 }
-```
-
-## Alternative Source File Extensions
-
-Alternative file extensions to try if the source file does not exist. Example:
-
-```json
-// Local path: /var/www/html/test.php
-"srcExtensions": [
-    "myphp", // ${workspaceRoot}/test.myphp
-    "myphp2" // ${workspaceRoot}/test.myphp2
-]
 ```
 
 Please also note that setting any of the CLI debugging options will not work with remote host debugging, because the script is always launched locally. If you want to debug a CLI script on a remote host, you need to launch it manually from the command line.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ In your project, go to the debugger and hit the little gear icon and choose _PHP
 - `port`: The port on which to listen for XDebug (default: `9000`)
 - `stopOnEntry`: Wether to break at the beginning of the script (default: `false`)
 - `pathMappings`: A list of server paths mapping to the local source paths on your machine, see "Remote Host Debugging" below
+- `srcExtensions`: Alternative file extensions to try if the source file does not exist. See "Alternative Source File Extensions"
 - `log`: Wether to log all communication between VS Code and the adapter to the debug console. See _Troubleshooting_ further down.
 - `ignore`: An optional array of glob patterns that errors should be ignored from (for example `**/vendor/**/*.php`)
 - `xdebugSettings`: Allows you to override XDebug's remote debugging settings to fine tuning XDebug to your needs. For example, you can play with `max_children` and `max_depth` to change the max number of array and object children that are retrieved and the max depth in structures like arrays and objects. This can speed up the debugger on slow machines.
@@ -96,6 +97,18 @@ To make VS Code map the files on the server to the right files on your local mac
   "/var/www/html": "${workspaceRoot}/www",
   "/app": "${workspaceRoot}/app"
 }
+```
+
+## Alternative Source File Extensions
+
+Alternative file extensions to try if the source file does not exist. Example:
+
+```json
+// Local path: /var/www/html/test.php
+"srcExtensions": [
+    "myphp", // ${workspaceRoot}/test.myphp
+    "myphp2" // ${workspaceRoot}/test.myphp2
+]
 ```
 
 Please also note that setting any of the CLI debugging options will not work with remote host debugging, because the script is always launched locally. If you want to debug a CLI script on a remote host, you need to launch it manually from the command line.

--- a/package-lock.json
+++ b/package-lock.json
@@ -331,6 +331,7 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -342,6 +343,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -1976,6 +1978,23 @@
         "object-assign": "^4.0.1"
       }
     },
+    "file-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/file-match/-/file-match-1.0.2.tgz",
+      "integrity": "sha1-ycrSZdLIrfOoFHWw30dYWQafrvc=",
+      "requires": {
+        "utils-extend": "^1.0.6"
+      }
+    },
+    "file-system": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/file-system/-/file-system-2.2.2.tgz",
+      "integrity": "sha1-fWWDPjojR9zZVqgTxncVPtPt2Yc=",
+      "requires": {
+        "file-match": "^1.0.1",
+        "utils-extend": "^1.0.4"
+      }
+    },
     "file-url": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/file-url/-/file-url-2.0.2.tgz",
@@ -2955,7 +2974,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "loud-rejection": {
       "version": "1.6.0",
@@ -6525,6 +6545,7 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -7335,7 +7356,8 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "loose-envify": {
           "version": "1.3.1",
@@ -9751,6 +9773,11 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
+    },
+    "utils-extend": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/utils-extend/-/utils-extend-1.0.8.tgz",
+      "integrity": "sha1-zP17ZFQPjpDuIe7Fd2nQZRyril8="
     },
     "validate-commit-msg": {
       "version": "2.14.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "url": "https://github.com/felixfbecker/vscode-php-debug/issues"
   },
   "dependencies": {
+    "file-system": "^2.2.2",
     "file-url": "^2.0.0",
     "iconv-lite": "^0.4.15",
     "minimatch": "^3.0.3",
@@ -199,6 +200,14 @@
                 "type": "object",
                 "default": {},
                 "description": "A mapping of server paths to local paths."
+              },
+              "srcExtensions": {
+                "type": "array",
+                "description": "Alternative source file extensions.",
+                "items": {
+                  "type": "string"
+                },
+                "default": []
               },
               "ignore": {
                 "type": "array",

--- a/package.json
+++ b/package.json
@@ -201,14 +201,6 @@
                 "default": {},
                 "description": "A mapping of server paths to local paths."
               },
-              "srcExtensions": {
-                "type": "array",
-                "description": "Alternative source file extensions.",
-                "items": {
-                  "type": "string"
-                },
-                "default": []
-              },
               "ignore": {
                 "type": "array",
                 "items": "string",

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -9,7 +9,7 @@ import { decode } from 'urlencode'
 export function convertDebuggerPathToClient(
     fileUri: string | url.Url,
     pathMapping?: { [index: string]: string },
-    srcExtensions?: string[] | undefined
+    env?:{ [key: string]: string | undefined }
 ): string {
     let localSourceRoot: string | undefined
     let serverSourceRoot: string | undefined
@@ -44,10 +44,10 @@ export function convertDebuggerPathToClient(
         )
         // resolve from the local source root
         localPath = path.resolve(localSourceRoot, pathRelativeToSourceRoot)
-
-        if (srcExtensions && !FS.existsSync(localPath)) {
-            const extPattern = new RegExp("/\.[^.]+$/", 'g')
-            srcExtensions.some(
+        if (env && env.srcExtensions && !FS.existsSync(localPath)) {
+            const extPattern = new RegExp(/\.[^.]+$/, 'g')
+            const extList = env.srcExtensions.split(',')
+            extList.some(
                 (ext): any => {
                     if (FS.existsSync(localPath.replace(extPattern, '.' + ext))) {
                         return (localPath = localPath.replace(extPattern, '.' + ext))

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -1,5 +1,6 @@
 import urlRelative = require('url-relative')
 import fileUrl = require('file-url')
+import FS = require('fs')
 import * as url from 'url'
 import * as path from 'path'
 import { decode } from 'urlencode'
@@ -7,7 +8,8 @@ import { decode } from 'urlencode'
 /** converts a server-side XDebug file URI to a local path for VS Code with respect to source root settings */
 export function convertDebuggerPathToClient(
     fileUri: string | url.Url,
-    pathMapping?: { [index: string]: string }
+    pathMapping?: { [index: string]: string },
+    srcExtensions?: string[] | undefined
 ): string {
     let localSourceRoot: string | undefined
     let serverSourceRoot: string | undefined
@@ -42,6 +44,17 @@ export function convertDebuggerPathToClient(
         )
         // resolve from the local source root
         localPath = path.resolve(localSourceRoot, pathRelativeToSourceRoot)
+
+        if (srcExtensions && !FS.existsSync(localPath)) {
+            var extPattern = /\.[^.]+$/
+            srcExtensions.some(
+                (ext): any => {
+                    if (FS.existsSync(localPath.replace(extPattern, '.' + ext))) {
+                        return (localPath = localPath.replace(extPattern, '.' + ext))
+                    }
+                }
+            )
+        }
     } else {
         localPath = path.normalize(serverPath)
     }

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -46,7 +46,7 @@ export function convertDebuggerPathToClient(
         localPath = path.resolve(localSourceRoot, pathRelativeToSourceRoot)
 
         if (srcExtensions && !FS.existsSync(localPath)) {
-            var extPattern = new RegExp(/\.[^.]+$/, "g");
+            const extPattern = new RegExp("/\.[^.]+$/", 'g')
             srcExtensions.some(
                 (ext): any => {
                     if (FS.existsSync(localPath.replace(extPattern, '.' + ext))) {

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -46,7 +46,7 @@ export function convertDebuggerPathToClient(
         localPath = path.resolve(localSourceRoot, pathRelativeToSourceRoot)
 
         if (srcExtensions && !FS.existsSync(localPath)) {
-            var extPattern = /\.[^.]+$/
+            var extPattern = new RegExp(/\.[^.]+$/, "g");
             srcExtensions.some(
                 (ext): any => {
                     if (FS.existsSync(localPath.replace(extPattern, '.' + ext))) {

--- a/src/phpDebug.ts
+++ b/src/phpDebug.ts
@@ -62,8 +62,6 @@ interface LaunchRequestArguments extends VSCodeDebugProtocol.LaunchRequestArgume
     localSourceRoot?: string
     /** The path to the source root on this machine that is the equivalent to the serverSourceRoot on the server. */
     pathMappings?: { [index: string]: string }
-    /** Alternative file extensions to try if the source file does not exist. */
-    srcExtensions?: string[]
     /** If true, will log all communication between VS Code and the adapter to the console */
     log?: boolean
     /** Array of glob patterns that errors should be ignored from */
@@ -698,7 +696,7 @@ class PhpDebugSession extends vscode.DebugSession {
                     line++
                 } else {
                     // XDebug paths are URIs, VS Code file paths
-                    const filePath = convertDebuggerPathToClient(urlObject, this._args.pathMappings, this._args.srcExtensions)
+                    const filePath = convertDebuggerPathToClient(urlObject, this._args.pathMappings, this._args.env)
                     // "Name" of the source and the actual file path
                     source = { name: path.basename(filePath), path: filePath }
                 }
@@ -724,7 +722,7 @@ class PhpDebugSession extends vscode.DebugSession {
                                 line++
                             } else {
                                 // XDebug paths are URIs, VS Code file paths
-                                const filePath = convertDebuggerPathToClient(urlObject, this._args.pathMappings, this._args.srcExtensions)
+                                const filePath = convertDebuggerPathToClient(urlObject, this._args.pathMappings, this._args.env)
                                 // "Name" of the source and the actual file path
                                 source = { name: path.basename(filePath), path: filePath }
                             }

--- a/src/phpDebug.ts
+++ b/src/phpDebug.ts
@@ -62,6 +62,8 @@ interface LaunchRequestArguments extends VSCodeDebugProtocol.LaunchRequestArgume
     localSourceRoot?: string
     /** The path to the source root on this machine that is the equivalent to the serverSourceRoot on the server. */
     pathMappings?: { [index: string]: string }
+    /** Alternative file extensions to try if the source file does not exist. */
+    srcExtensions?: string[]
     /** If true, will log all communication between VS Code and the adapter to the console */
     log?: boolean
     /** Array of glob patterns that errors should be ignored from */
@@ -696,7 +698,7 @@ class PhpDebugSession extends vscode.DebugSession {
                     line++
                 } else {
                     // XDebug paths are URIs, VS Code file paths
-                    const filePath = convertDebuggerPathToClient(urlObject, this._args.pathMappings)
+                    const filePath = convertDebuggerPathToClient(urlObject, this._args.pathMappings, this._args.srcExtensions)
                     // "Name" of the source and the actual file path
                     source = { name: path.basename(filePath), path: filePath }
                 }
@@ -722,7 +724,7 @@ class PhpDebugSession extends vscode.DebugSession {
                                 line++
                             } else {
                                 // XDebug paths are URIs, VS Code file paths
-                                const filePath = convertDebuggerPathToClient(urlObject, this._args.pathMappings)
+                                const filePath = convertDebuggerPathToClient(urlObject, this._args.pathMappings, this._args.srcExtensions)
                                 // "Name" of the source and the actual file path
                                 source = { name: path.basename(filePath), path: filePath }
                             }


### PR DESCRIPTION
I use multiple custom file extensions in my source folder, and these files are automatically build with the .php extension. 

For instance, the configuration is saved in the build folder as **.php** when I process the **.myphp1** **.myphp2** etc. files. 

With these changes, xDebug is identified with srcExtensions items when it cannot find a .php file in its source folder, trying alternative file extensions. 