### PR TITLE
fix: reset "stopOnEntry" after first use to show correct pause reason

### DIFF
--- a/src/phpDebug.ts
+++ b/src/phpDebug.ts
@@ -140,6 +140,9 @@ class PhpDebugSession extends vscode.DebugSession {
     /** A map from unique VS Code variable IDs to XDebug eval result properties, because property children returned from eval commands are always inlined */
     private _evalResultProperties = new Map<number, xdebug.EvalResultProperty>()
 
+    /** A flag to indicate that the adapter has already processed the stopOnEntry step request */
+    private _hasStoppedOnEntry = false
+
     public constructor() {
         super()
         this.setDebuggerColumnsStartAt1(true)
@@ -363,9 +366,9 @@ class PhpDebugSession extends vscode.DebugSession {
                 }
                 stoppedEventReason = 'exception'
                 exceptionText = response.exception.name + ': ' + response.exception.message // this seems to be ignored currently by VS Code
-            } else if (this._args.stopOnEntry) {
+            } else if (this._args.stopOnEntry && !this._hasStoppedOnEntry) {
                 stoppedEventReason = 'entry'
-                this._args.stopOnEntry = false
+                this._hasStoppedOnEntry = true
             } else if (response.command.indexOf('step') === 0) {
                 stoppedEventReason = 'step'
             } else {
@@ -624,6 +627,7 @@ class PhpDebugSession extends vscode.DebugSession {
                     // either tell VS Code we stopped on entry or run the script
                     if (this._args.stopOnEntry) {
                         // do one step to the first statement
+                        this._hasStoppedOnEntry = false
                         return connection.sendStepIntoCommand()
                     } else {
                         return connection.sendRunCommand()

--- a/src/phpDebug.ts
+++ b/src/phpDebug.ts
@@ -365,6 +365,7 @@ class PhpDebugSession extends vscode.DebugSession {
                 exceptionText = response.exception.name + ': ' + response.exception.message // this seems to be ignored currently by VS Code
             } else if (this._args.stopOnEntry) {
                 stoppedEventReason = 'entry'
+                this._args.stopOnEntry = false
             } else if (response.command.indexOf('step') === 0) {
                 stoppedEventReason = 'step'
             } else {


### PR DESCRIPTION
If "stopOnEntry" is enabled the pause reason will always be "Paused on entry" event if it's the result of a step operation or breakpoint. Resetting the "stopOnEntry" after first use solves the issue. The flag is not used anywhere else.