### PR TITLE
feat: multi session debugging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1195,6 +1195,12 @@
       "integrity": "sha512-4Gqya3/CmZ280CA6DvBnHmnq/vfgIqXJvzUC2S7a8kxmv/gbmt0uhJbx6m7ypWJvNn9n8DKWj5LD8wFpSxeQuA==",
       "dev": true
     },
+    "@types/vscode": {
+      "version": "1.53.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.53.0.tgz",
+      "integrity": "sha512-XjFWbSPOM0EKIT2XhhYm3D3cx3nn3lshMUcWNy1eqefk+oqRuBq8unVb6BYIZqXy9lQZyeUl7eaBCOZWv+LcXQ==",
+      "dev": true
+    },
     "@types/xmldom": {
       "version": "0.1.30",
       "resolved": "https://registry.npmjs.org/@types/xmldom/-/xmldom-0.1.30.tgz",
@@ -2438,7 +2444,7 @@
         "readable-stream": {
           "version": "2.3.7",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
           "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
@@ -2462,7 +2468,7 @@
         "string_decoder": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
           "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -2679,7 +2685,7 @@
     "human-signals": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-      "integrity": "sha1-3JH8ukLk0G5Kuu0zs+ejwC9RTqA=",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "dev": true
     },
     "husky": {
@@ -3757,7 +3763,7 @@
     "merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-      "integrity": "sha1-UoI2KaFN0AyXcPtq1H3GMQ8sH2A=",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true
     },
     "merge2": {
@@ -8943,7 +8949,7 @@
     "strip-final-newline": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-      "integrity": "sha1-ibhS+y/L6Tb29LMYevsKEsGrWK0=",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
       "dev": true
     },
     "strip-json-comments": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@types/semver": "^7.3.4",
     "@types/urlencode": "^1.1.2",
     "@types/xmldom": "^0.1.30",
+    "@types/vscode": "^1.53.0",
     "chai": "^4.3.0",
     "chai-as-promised": "^7.1.1",
     "husky": "^4.3.8",
@@ -130,6 +131,10 @@
       "out/test/**/*.*"
     ]
   },
+  "main": "./out/extension.js",
+  "activationEvents": [
+    "onDebug"
+  ],
   "contributes": {
     "breakpoints": [
       {
@@ -302,12 +307,12 @@
               "port": 0,
               "runtimeArgs": [
                 "-dxdebug.start_with_request=yes"
-                ],
-                "env": {
-                  "XDEBUG_MODE": "debug,develop",
-                  "XDEBUG_CONFIG": "^\"client_port=\\${port\\}\""
-                }
+              ],
+              "env": {
+                "XDEBUG_MODE": "debug,develop",
+                "XDEBUG_CONFIG": "^\"client_port=\\${port\\}\""
               }
+            }
           },
           {
             "label": "PHP: Launch currently open script with Xdebug 2",

--- a/package.json
+++ b/package.json
@@ -202,7 +202,7 @@
               "port": {
                 "type": "number",
                 "description": "Port on which to listen for Xdebug",
-                "default": 9000
+                "default": 9003
               },
               "serverSourceRoot": {
                 "type": "string",
@@ -261,7 +261,7 @@
             "name": "Listen for Xdebug",
             "type": "php",
             "request": "launch",
-            "port": 9000
+            "port": 9003
           },
           {
             "name": "Launch currently open script",
@@ -269,7 +269,62 @@
             "request": "launch",
             "program": "${file}",
             "cwd": "${fileDirname}",
-            "port": 9000
+            "port": 0,
+            "runtimeArgs": [
+              "-dxdebug.start_with_request=yes"
+            ],
+            "env": {
+              "XDEBUG_MODE": "debug,develop",
+              "XDEBUG_CONFIG": "client_port=${port}"
+            }
+          }
+        ],
+        "configurationSnippets": [
+          {
+            "label": "PHP: Listen for Xdebug",
+            "description": "Listening for Xdebug",
+            "body": {
+              "name": "Listen for Xdebug",
+              "type": "php",
+              "request": "launch",
+              "port": 9003
+            }
+          },
+          {
+            "label": "PHP: Launch currently open script",
+            "description": "Launch currently open script",
+            "body": {
+              "name": "Launch currently open script",
+              "type": "php",
+              "request": "launch",
+              "program": "^\"${1:\\${file\\}}\"",
+              "cwd": "^\"${2:\\${fileDirname\\}}\"",
+              "port": 0,
+              "runtimeArgs": [
+                "-dxdebug.start_with_request=yes"
+                ],
+                "env": {
+                  "XDEBUG_MODE": "debug,develop",
+                  "XDEBUG_CONFIG": "^\"client_port=\\${port\\}\""
+                }
+              }
+          },
+          {
+            "label": "PHP: Launch currently open script with Xdebug 2",
+            "description": "Launch currently open script",
+            "body": {
+              "name": "Launch currently open script",
+              "type": "php",
+              "request": "launch",
+              "program": "^\"${1:\\${file\\}}\"",
+              "cwd": "^\"${2:\\${fileDirname\\}}\"",
+              "port": 0,
+              "runtimeArgs": [
+                "-dxdebug.remote_enable=1",
+                "-dxdebug.remote_autostart=1",
+                "^\"-dxdebug.remote_port=\\${port\\}\""
+              ]
+            }
           }
         ]
       }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,0 +1,45 @@
+import * as vscode from 'vscode'
+import { PhpDebugSession} from './phpDebug'
+
+export function activate(context: vscode.ExtensionContext) {
+    console.log('activate')
+
+    context.subscriptions.push(vscode.debug.onDidStartDebugSession(session => {
+        console.log('onDidStartDebugSession', session)
+        //session.customRequest('test1', { test2: "test3" })
+    }))
+    context.subscriptions.push(vscode.debug.onDidTerminateDebugSession(session => {
+        console.log('onDidTerminateDebugSession', session)
+    }))
+
+    context.subscriptions.push(vscode.debug.onDidReceiveDebugSessionCustomEvent(event => {
+        console.log('onDidReceiveDebugSessionCustomEvent', event)
+        if (event.event === 'newDbgpConnection') {
+            const config: vscode.DebugConfiguration = {
+                ...event.session.configuration
+            }
+            config.request = 'attach'
+            config.name = 'DBGp connection ' + event.body.connId
+            config.connId = event.body.connId
+            vscode.debug.startDebugging(undefined, config, event.session)
+        }
+    }))
+
+    const factory = new InlineDebugAdapterFactory()
+	context.subscriptions.push(vscode.debug.registerDebugAdapterDescriptorFactory('php', factory));
+	if ('dispose' in factory) {
+		context.subscriptions.push(factory);
+	}    
+}
+
+export function deactivate() {
+    console.log('deactivate')
+}
+
+class InlineDebugAdapterFactory implements vscode.DebugAdapterDescriptorFactory {
+
+	createDebugAdapterDescriptor(_session: vscode.DebugSession): vscode.ProviderResult<vscode.DebugAdapterDescriptor> {
+		// since DebugAdapterInlineImplementation is proposed API, a cast to <any> is required for now
+		return <any>new vscode.DebugAdapterInlineImplementation(new PhpDebugSession());
+	}
+}

--- a/src/phpDebug.ts
+++ b/src/phpDebug.ts
@@ -205,16 +205,18 @@ class PhpDebugSession extends vscode.DebugSession {
         }
         this._args = args
         /** launches the script as CLI */
-        const launchScript = async () => {
+        const launchScript = async (port: number) => {
             // check if program exists
             await new Promise<void>((resolve, reject) =>
                 fs.access(args.program!, fs.constants.F_OK, err => (err ? reject(err) : resolve()))
             )
-            const runtimeArgs = args.runtimeArgs || []
+            const runtimeArgs = (args.runtimeArgs || []).map(v => v.replace('${port}', port.toString()))
             const runtimeExecutable = args.runtimeExecutable || 'php'
             const programArgs = args.args || []
             const cwd = args.cwd || process.cwd()
-            const env = args.env || process.env
+            const env = Object.fromEntries(
+                Object.entries(args.env || process.env).map(v => [v[0], v[1]?.replace('${port}', port.toString())])
+            )
             // launch in CLI mode
             if (args.externalConsole) {
                 const script = await Terminal.launchInTerminal(
@@ -252,7 +254,7 @@ class PhpDebugSession extends vscode.DebugSession {
         }
         /** sets up a TCP server to listen for Xdebug connections */
         const createServer = () =>
-            new Promise<void>((resolve, reject) => {
+            new Promise<number>((resolve, reject) => {
                 const server = (this._server = net.createServer())
                 server.on('connection', async (socket: net.Socket) => {
                     try {
@@ -316,16 +318,22 @@ class PhpDebugSession extends vscode.DebugSession {
                 })
                 server.on('error', (error: Error) => {
                     this.sendEvent(new vscode.OutputEvent(util.inspect(error) + '\n'))
-                    this.sendErrorResponse(response, <Error>error)
+                    reject(error)
                 })
-                server.listen(args.port || 9000, args.hostname, () => resolve())
+                server.on('listening', () => {
+                    const port = (server.address() as net.AddressInfo).port
+                    resolve(port)
+                })
+                const listenPort = args.port === undefined ? 9000 : args.port
+                server.listen(listenPort, args.hostname)
             })
         try {
+            let port = 0
             if (!args.noDebug) {
-                await createServer()
+                port = await createServer()
             }
             if (args.program) {
-                await launchScript()
+                await launchScript(port)
             }
         } catch (error) {
             this.sendErrorResponse(response, <Error>error)

--- a/testproject/.vscode/launch.json
+++ b/testproject/.vscode/launch.json
@@ -1,4 +1,7 @@
 {
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
   "version": "0.2.0",
   "configurations": [
     {
@@ -6,17 +9,22 @@
       "name": "Listen for Xdebug",
       "type": "php",
       "request": "launch",
-      "port": 9000,
+      "port": 9003,
       "log": true
     },
     {
       //"debugServer": 4711, // Uncomment for debugging the adapter
-      "name": "Launch",
-      "request": "launch",
+      "name": "Launch currently open script",
       "type": "php",
+      "request": "launch",
       "program": "${file}",
-      "cwd": "${workspaceRoot}",
-      "externalConsole": false
+      "cwd": "${fileDirname}",
+      "port": 0,
+      "runtimeArgs": ["-dxdebug.start_with_request=yes"],
+      "env": {
+        "XDEBUG_MODE": "debug,develop",
+        "XDEBUG_CONFIG": "client_port=${port}"
+      }
     }
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "include": ["src/**/*"],
   "compilerOptions": {
-    "target": "es6",
+    "target": "es2019",
     "module": "commonjs",
     "rootDir": "src",
     "outDir": "out",


### PR DESCRIPTION
Current support for multiple sessions is implemented by presenting different Xdebug sessions as DAP threads. The correct way of doing this would be to present each Xdebug session as individual DAP session. The DAP in it self does not support this (https://github.com/microsoft/vscode/issues/116730) however vscode does, by extension code: https://code.visualstudio.com/api/extension-guides/debugger-extension#alternative-approach-to-develop-a-debugger-extension

The implementation I chose starts one DAP session that listens for Xdebug sessions. When Xdebug receives a connection a custom event is sent to extension code, and than in turn spawns a new DAP session. The socket object is stored statically and referenced via  uniq id.

This way each Xdebug session has an isolated DAP state.