### PR TITLE
chore(release): add marketplace link to release notes

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,13 +82,14 @@
     ],
     "prepare": {
       "path": "semantic-release-vsce",
-      "packageVsix": "php-debug.vsix"
+      "packageVsix": true
     },
     "publish": [
       "semantic-release-vsce",
       {
         "path": "@semantic-release/github",
-        "assets": "php-debug.vsix"
+        "assets": "*.vsix",
+        "addReleases": "bottom"
       }
     ]
   },


### PR DESCRIPTION
And also uses the versioned `.vsix` to upload to GitHub Releases.

As in [vscode-shellcheck](https://github.com/timonwong/vscode-shellcheck/blame/3a803d31912b863985405da042339db98fda0c56/release.config.js#L57-L72).