### PR TITLE
feat: Add supportTerminateDebuggee

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
+
+## [1.15.0]
+
+### Added
+
+- Support for terminateDebuggee option letting the user choose to keep the debugee running. Press Alt when hovering over stop action.

--- a/src/phpDebug.ts
+++ b/src/phpDebug.ts
@@ -182,6 +182,7 @@ class PhpDebugSession extends vscode.DebugSession {
                     default: true,
                 },
             ],
+            supportTerminateDebuggee: true,
         }
         this.sendResponse(response)
     }
@@ -1012,9 +1013,14 @@ class PhpDebugSession extends vscode.DebugSession {
         try {
             await Promise.all(
                 Array.from(this._connections).map(async ([id, connection]) => {
-                    // Try to send stop command for 500ms
-                    // If the script is running, just close the connection
-                    await Promise.race([connection.sendStopCommand(), new Promise(resolve => setTimeout(resolve, 500))])
+                    if (args?.terminateDebuggee !== false) {
+                        // Try to send stop command for 500ms
+                        // If the script is running, just close the connection
+                        await Promise.race([
+                            connection.sendStopCommand(),
+                            new Promise(resolve => setTimeout(resolve, 500)),
+                        ])
+                    }
                     await connection.close()
                     this._connections.delete(id)
                     this._waitingConnections.delete(connection)


### PR DESCRIPTION
Implement optional stop of debugee after VS Code UI is available from https://github.com/microsoft/vscode/issues/116731
