### PR TITLE
fix: Improve breakpoint handling with multiple connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.16.1]
+
+### Fixed
+
+- Do not request all breakpoints on every new Xdebug connection. Use internal BreakpointManager state.
+- Show breakpoints as verified when there are no connections.
+
 ## [1.16.0]
 
 ### Added

--- a/src/test/adapter.ts
+++ b/src/test/adapter.ts
@@ -367,8 +367,7 @@ describe('PHP Debug Adapter', () => {
             const program = path.join(TEST_PROJECT, 'function.php')
 
             it('should stop on a function breakpoint', async () => {
-                await client.launch({ program })
-                await client.waitForEvent('initialized')
+                await Promise.all([client.launch({ program }), client.waitForEvent('initialized')])
                 const breakpoint = (
                     await client.setFunctionBreakpointsRequest({
                         breakpoints: [{ name: 'a_function' }],


### PR DESCRIPTION
Request breakpoint info after initialization.
Sync breakpoints to Xdebug connection from internal BreakpointManager state.
Show breakpoints as verified if there are no connections.
Remove _waitingConnections map because the ConfigurationDone handler is not in use anymore.
Cleanup _statuses and _breakpointAdapters to prevent leaks.
Fix typos.
Fix test because the order of startup events changed.