### PR TITLE
fix: Improve init failure handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,28 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.21.1]
+
+### Fixed
+
+- Auto configure runtimeExecutable when only runtimeArgs are used (built-in web server).
+- Improve handling of broken clients on failed initPacket.
+
 ## [1.21.0]
+
+### Added
 
 - Support for maxConnections limiting how many parallel connections the debug adapter allows.
 
 ## [1.20.0]
 
+### Added
+
 - Support no-folder debugging in (purple) VS Code.
 
 ## [1.19.0]
 
-## Added
+### Added
 
 - Support for PHP 8.1 facets
 - Support for Xdebug 3.1 xdebug_notify()
@@ -25,19 +36,19 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [1.17.0]
 
-## Added
+### Added
 
 - Added logpoint support.
 
 ## [1.16.3]
 
-## Fixed
+### Fixed
 
 - Fixed semver dependency error.
 
 ## [1.16.2]
 
-## Fixed
+### Fixed
 
 - Fixed breakpoint and launch initialization order.
 - Optimize feature negotiation for known Xdebug version.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,7 +28,10 @@ export function activate(context: vscode.ExtensionContext) {
                         // debugConfiguration.stopOnEntry = true
                     }
                 }
-                if (debugConfiguration.program && !debugConfiguration.runtimeExecutable) {
+                if (
+                    (debugConfiguration.program || debugConfiguration.runtimeArgs) &&
+                    !debugConfiguration.runtimeExecutable
+                ) {
                     // See if we have runtimeExecutable configured
                     const conf = vscode.workspace.getConfiguration('php')
                     const executablePath =


### PR DESCRIPTION
If DBGp initialization fails, disconnect the client, but leave adapter in tact.