### PR TITLE
fix: Fixes erroneous non-null args.env check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.29.1]
+
+- Fix for env configuration check that sometimes causes an error.
+
 ## [1.29.0]
 
 - Xdebug Cloud support.

--- a/src/phpDebug.ts
+++ b/src/phpDebug.ts
@@ -414,7 +414,12 @@ class PhpDebugSession extends vscode.DebugSession {
             })
         try {
             // Some checks
-            if ((args.env && Object.keys(args.env).length !== 0) && args.program === undefined && args.runtimeArgs === undefined) {
+            if (
+                args.env &&
+                Object.keys(args.env).length !== 0 &&
+                args.program === undefined &&
+                args.runtimeArgs === undefined
+            ) {
                 throw new Error(
                     `Cannot set env without running a program.\nPlease remove env from [${
                         args.name || 'unknown'

--- a/src/phpDebug.ts
+++ b/src/phpDebug.ts
@@ -414,7 +414,7 @@ class PhpDebugSession extends vscode.DebugSession {
             })
         try {
             // Some checks
-            if (args.env !== undefined && args.program === undefined && args.runtimeArgs === undefined) {
+            if ((args.env && Object.keys(args.env).length !== 0) && args.program === undefined && args.runtimeArgs === undefined) {
                 throw new Error(
                     `Cannot set env without running a program.\nPlease remove env from [${
                         args.name || 'unknown'

--- a/src/test/adapter.ts
+++ b/src/test/adapter.ts
@@ -41,7 +41,7 @@ describe('PHP Debug Adapter', () => {
             ))
 
         it('should error on env without program', () =>
-            assert.isRejected(Promise.all([client.launch({ env: {} }), client.configurationSequence()])))
+            assert.isRejected(Promise.all([client.launch({ env: { some: 'key' } }), client.configurationSequence()])))
 
         it('should run program to the end', () =>
             Promise.all([


### PR DESCRIPTION
Upon further investigation of #788 and #860, I found that, by default, if "env" is not specified, VSCode does not set it to undefined, but sets it to an empty object `{}`.

![Code_2022-12-09_17-38-52](https://user-images.githubusercontent.com/5962118/206761423-3fece93c-3e67-423f-a7c7-68400f7b0d8a.png)

![Code_2022-12-09_17-38-47](https://user-images.githubusercontent.com/5962118/206761455-b36b217f-1426-46bf-99cc-168291458ead.png)

The extension code here checks if args.env is not equal to undefined. By logic, undefined is not equal to {} (thanks JavaScript..), thus, with the default "Listen for Xdebug" configuration launched, it will still throw this error needlessly.

![Code_2022-12-09_17-38-42](https://user-images.githubusercontent.com/5962118/206761488-67a65aad-7d00-45cf-89ff-ff0e3b14179f.png)

I've made a fix for this by, instead, checking if args.env is equal to true (which is the equivalent of !== undefined) - and, **also checks** if there are more than 0 keys in the object, a.k.a the object is not empty. I can confirm that the debugger now runs normally with the default "Listen for Xdebug" configuration in my project.