### PR TITLE
fix: namespaced exceptions could not be ignored

### DIFF
--- a/src/phpDebug.ts
+++ b/src/phpDebug.ts
@@ -676,7 +676,7 @@ class PhpDebugSession extends vscode.DebugSession {
                         )) ||
                     // ignore exception class name
                     (this._args.ignoreExceptions &&
-                        this._args.ignoreExceptions.some(glob => minimatch(response.exception.name, glob)))
+                        this._args.ignoreExceptions.some(glob => response.exception.name === glob))
                 ) {
                     const response = await connection.sendRunCommand()
                     await this._checkStatus(response)

--- a/src/test/adapter.ts
+++ b/src/test/adapter.ts
@@ -215,7 +215,7 @@ describe('PHP Debug Adapter', () => {
             it('should not break on exception that matches the ignore pattern', async () => {
                 const program = path.join(TEST_PROJECT, 'ignore_exception.php')
 
-                await client.launch({ program, ignoreExceptions: ['IgnoreException'] })
+                await client.launch({ program, ignoreExceptions: ['App\\IgnoreException'] })
                 await client.setExceptionBreakpointsRequest({ filters: ['*'] })
                 await Promise.all([client.configurationDoneRequest(), client.waitForEvent('terminated')])
             })

--- a/testproject/.vscode/launch.json
+++ b/testproject/.vscode/launch.json
@@ -22,7 +22,7 @@
         "XDEBUG_MODE": "debug,develop",
         "XDEBUG_CONFIG": "client_port=${port}"
       },
-      "ignoreExceptions": ["IgnoreException"]
+      "ignoreExceptions": ["App\\IgnoreException"]
     },
     {
       //"debugServer": 4711, // Uncomment for debugging the adapter

--- a/testproject/ignore_exception.php
+++ b/testproject/ignore_exception.php
@@ -1,11 +1,22 @@
 <?php
 
-class IgnoreException extends Exception
+namespace App;
+
+class IgnoreException extends \Exception
+{}
+
+class NotIgnoreException extends \Exception
 {}
 
 try {
     // see launch.json ignoreExceptions
-    throw new IgnoreException('this is an ignored exception');
-} catch (Exception $e) {
+    throw new IgnoreException('This exception is ignored');
+} catch (\Exception $e) {
+    //
+}
+
+try {
+    throw new NotIgnoreException('This exception is not ignored');
+} catch (\Exception $e) {
     //
 }


### PR DESCRIPTION
- Namespaced exceptions could not be ignored. I decided to remove minimatch and use a simple comparison instead, because it says `You must use forward-slashes only in glob expressions`.
- Improve ignored exceptions example
