### PR TITLE
feat: Add skipEntryPaths to immediately detach a debug session depending on entry path

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ More general information on debugging with VS Code can be found on https://code.
 - `ignore`: An optional array of glob patterns that errors should be ignored from (for example `**/vendor/**/*.php`)
 - `ignoreExceptions`: An optional array of exception class names that should be ignored (for example `BaseException`, `\NS1\Exception`, `\*\Exception` or `\**\Exception*`)
 - `skipFiles`: An array of glob patterns, to skip when debugging. Star patterns and negations are allowed, for example, `**/vendor/**` or `!**/vendor/my-module/**`.
+- `skipEntryPaths`: An array of glob patterns, to immediately detach from and ignore for debugging if the entry script matches (example `**/ajax.php`).
 - `maxConnections`: Accept only this number of parallel debugging sessions. Additional connections will be dropped and their execution will continue without debugging.
 - `proxy`: DBGp Proxy settings
   - `enable`: To enable proxy registration set to `true` (default is `false).

--- a/package.json
+++ b/package.json
@@ -283,6 +283,11 @@
                 "items": "string",
                 "description": "An array of exception class names that should be ignored."
               },
+              "skipEntryPaths": {
+                "type": "array",
+                "items": "string",
+                "description": "An array of glob pattern to skip if the initial entry file is matched."
+              },
               "log": {
                 "type": "boolean",
                 "description": "If true, will log all communication between VS Code and the adapter"

--- a/src/xdebugConnection.ts
+++ b/src/xdebugConnection.ts
@@ -28,8 +28,8 @@ export class InitPacket {
         this.language = documentElement.getAttribute('language')!
         this.protocolVersion = documentElement.getAttribute('protocol_version')!
         this.ideKey = documentElement.getAttribute('idekey')!
-        this.engineVersion = documentElement.getElementsByTagName('engine')[0].getAttribute('version')!
-        this.engineName = documentElement.getElementsByTagName('engine')[0].textContent ?? ''
+        this.engineVersion = documentElement.getElementsByTagName('engine').item(0)?.getAttribute('version') ?? ''
+        this.engineName = documentElement.getElementsByTagName('engine').item(0)?.textContent ?? ''
         this.connection = connection
     }
 }


### PR DESCRIPTION
Add new configuration directive to configure if the debugger should immediately detach/disconnect from a session matching paths defined. 