### PR TITLE
fix: fullscreen keybinding conflict with F11 with activeViewlet

### DIFF
--- a/package.json
+++ b/package.json
@@ -576,12 +576,12 @@
       {
         "command": "extension.php-debug.startWithStopOnEntry",
         "key": "F10",
-        "when": "!inDebugMode && debugConfigurationType == 'php'"
+        "when": "!inDebugMode && activeViewlet == 'workbench.view.debug' && debugConfigurationType == 'php'"
       },
       {
         "command": "extension.php-debug.startWithStopOnEntry",
         "key": "F11",
-        "when": "!inDebugMode && debugConfigurationType == 'php'"
+        "when": "!inDebugMode && activeViewlet == 'workbench.view.debug' && debugConfigurationType == 'php'"
       }
     ]
   }

--- a/package.json
+++ b/package.json
@@ -576,7 +576,7 @@
       {
         "command": "extension.php-debug.startWithStopOnEntry",
         "key": "F10",
-        "when": "!inDebugMode && activeViewlet == 'workbench.view.debug' && debugConfigurationType == 'php'"
+        "when": "!inDebugMode && debugConfigurationType == 'php'"
       },
       {
         "command": "extension.php-debug.startWithStopOnEntry",


### PR DESCRIPTION
As the PR title suggests, this fixes key bindings collisions with Fullscreen mode.